### PR TITLE
🐛 Pins 6.0.0 BH-CE version, bug fix, admin password won't expire

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ ludus:
       block_internet: false
     roles:
       - badsectorlabs.ludus_bloodhound_ce
+    role_vars:
+      ludus_bloodhound_port: "80"
+      ludus_bloodhound_admin_password: "bloodhoundpassword123"
 ```
 
 ## Ludus setup

--- a/README.md
+++ b/README.md
@@ -2,18 +2,11 @@
 
 An Ansible Role that installs [Bloodhound-CE](https://github.com/SpecterOps/BloodHound) on a debian based system.
 
+- Install Bloodhound-CE version `6.0.0`
+- Uses `bloodhoundpassword` as default password. Can be changed using `role_vars`.
 - Checks if {{ ludus_bloodhound_ce_install_path }}/docker-compose.yml exists
 - If not, it installs vanilla bloodhound-ce (via docker-compose)
 - Outputs the admin password in bloodhound_ce_install_path (default: `/opt/bloodhound`)
-
-To force the role to re-run, stop the docker container and remove the ludus_bloodhound_ce_install_path folder
-
-```
-cd /opt/bloodhound
-docker compose down
-cd ..
-rm -rf /opt/bloodhound
-```
 
 ## Requirements
 
@@ -25,17 +18,21 @@ Available variables are listed below, along with default values (see `defaults/m
 
     # Path where docker-compose.yml and admin creds are placed
     ludus_bloodhound_ce_install_path: /opt/bloodhound
-    # Expose bloodhound web UI to 0.0.0.0:8080 if set to false (default: true)
-    ludus_bloodhound_listen_only_localhost: true
+
+    # Expose bloodhound web UI to 0.0.0.0:8080 if set to false (default: false)
+    ludus_bloodhound_listen_only_localhost: false
+
     # The port bloodhound CE listens on
     ludus_bloodhound_port: "8080"
-    # The default admin password for bloodhound (default: generate a random password)
-    ludus_bloodhound_admin_password:
+
+    # The default admin password for bloodhound (default: bloodhoundpassword)
+    ludus_bloodhound_admin_password: "bloodhoundpassword"
+
     # Other admin details defaults
-    ludus_bloodhound_admin_principal_name: 'admin'
-    ludus_bloodhound_admin_email_address: 'email@bloodhound.ludus'
-    ludus_bloodhound_admin_first_name: 'Bloodhound'
-    ludus_bloodhound_admin_last_name: 'Admin'
+    ludus_bloodhound_admin_principal_name: "admin"
+    ludus_bloodhound_admin_email_address: "admin@ludus.domain"
+    ludus_bloodhound_admin_first_name: "Bloodhound"
+    ludus_bloodhound_admin_last_name: "Admin"
 
 ## Dependencies
 
@@ -58,25 +55,42 @@ ludus:
       block_internet: false
     roles:
       - badsectorlabs.ludus_bloodhound_ce
-    role_vars:
-      ludus_bloodhound_listen_only_localhost: false
 ```
 
 ## Ludus setup
 
 ```
+# Add the role to the ludus user ansible role inventory
 ludus ansible roles add badsectorlabs.ludus_bloodhound_ce
+
+# Get the current range config
 ludus range config get > config.yml
+
 # Edit config to add the role to the VMs you wish to install bloodhound on and define your desired ludus_bloodhound_ce vars
 ludus range config set -f config.yml
-ludus range deploy -t user-defined-roles
+ludus range deploy
 ```
+
+## Trobleshooting
+
+To force the role to re-run (fresh Bloodhound instance), SSH into the VM, stop the docker container and remove the ludus_bloodhound_ce_install_path folder (default to `/opt/bloodhound`)
+
+```
+cd /opt/bloodhound
+docker compose down
+cd ..
+# assuming there are no other docker volumes used by other containers
+xargs -r docker volume rm
+rm -rf /opt/bloodhound
+```
+
+This removes the existing bloodhound related docker containers and volumes.
 
 ## License
 
 Apache 2.0
 
-Role installs [Bloodhound-CE](https://github.com/SpecterOps/BloodHound). Credits to the SpecterOps team for the amazing contributions to the industry.
+This Ludus role installs [Bloodhound-CE](https://github.com/SpecterOps/BloodHound). Credits to the SpecterOps team for the amazing contributions to the industry.
 
 ## Author Information
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
 ludus_bloodhound_ce_install_path: /opt/bloodhound
-ludus_bloodhound_listen_only_localhost: true
+ludus_bloodhound_listen_only_localhost: false
 ludus_bloodhound_port: "8080"
-ludus_bloodhound_admin_password:
+ludus_bloodhound_admin_password: "bloodhoundpassword"
 ludus_bloodhound_admin_principal_name: "admin"
-ludus_bloodhound_admin_email_address: "email@bloodhound.ludus"
+ludus_bloodhound_admin_email_address: "admin@ludus.domain"
 ludus_bloodhound_admin_first_name: "Bloodhound"
 ludus_bloodhound_admin_last_name: "Admin"

--- a/files/docker-compose.yml
+++ b/files/docker-compose.yml
@@ -14,24 +14,24 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-version: '3'
 services:
   app-db:
-    image: docker.io/library/postgres:13.2
+    image: docker.io/library/postgres:16
     environment:
+      - PGUSER=${POSTGRES_USER:-bloodhound}
       - POSTGRES_USER=${POSTGRES_USER:-bloodhound}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-bloodhoundcommunityedition}
       - POSTGRES_DB=${POSTGRES_DB:-bloodhound}
     # Database ports are disabled by default. Please change your database password to something secure before uncommenting
-    # ports:
-    #   - 127.0.0.1:${POSTGRES_PORT:-5432}:5432
+    ports:
+      - 127.0.0.1:${POSTGRES_PORT:-5432}:5432
     volumes:
-      - ./postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql/data
     healthcheck:
       test:
         [
           "CMD-SHELL",
-          "pg_isready -U ${POSTGRES_USER:-bloodhound} -d ${POSTGRES_DB:-bloodhound} -h 127.0.0.1 -p ${POSTGRES_PORT:-5432}"
+          "pg_isready -U ${POSTGRES_USER:-bloodhound} -d ${POSTGRES_DB:-bloodhound} -h 127.0.0.1 -p ${POSTGRES_PORT:-5432}",
         ]
       interval: 10s
       timeout: 5s
@@ -48,12 +48,12 @@ services:
       - 127.0.0.1:${NEO4J_DB_PORT:-7687}:7687
       - 127.0.0.1:${NEO4J_WEB_PORT:-7474}:7474
     volumes:
-      - ./neo4j-data:/data
+      - ${NEO4J_DATA_MOUNT:-neo4j-data}:/data
     healthcheck:
       test:
         [
           "CMD-SHELL",
-          "wget -O /dev/null -q http://localhost:${NEO4J_WEB_PORT:-7474} || exit 1"
+          "wget -O /dev/null -q http://localhost:${NEO4J_WEB_PORT:-7474} || exit 1",
         ]
       interval: 10s
       timeout: 5s
@@ -63,7 +63,9 @@ services:
   bloodhound:
     image: docker.io/specterops/bloodhound:${BLOODHOUND_TAG:-latest}
     environment:
-      - bhe_disable_cypher_qc=${bhe_disable_cypher_qc:-false}
+      - bhe_disable_cypher_complexity_limit=${bhe_disable_cypher_complexity_limit:-false}
+      - bhe_enable_cypher_mutations=${bhe_enable_cypher_mutations:-false}
+      - bhe_graph_query_memory_limit=${bhe_graph_query_memory_limit:-2}
       - bhe_database_connection=user=${POSTGRES_USER:-bloodhound} password=${POSTGRES_PASSWORD:-bloodhoundcommunityedition} dbname=${POSTGRES_DB:-bloodhound} host=app-db
       - bhe_neo4j_connection=neo4j://${NEO4J_USER:-neo4j}:${NEO4J_SECRET:-bloodhoundcommunityedition}@graph-db:7687/
       - bhe_default_admin_password=${bhe_default_admin_password}
@@ -71,6 +73,7 @@ services:
       - bhe_default_admin_email_address=${bhe_default_admin_email_address}
       - bhe_default_admin_first_name=${bhe_default_admin_first_name}
       - bhe_default_admin_last_name=${bhe_default_admin_last_name}
+      - bhe_default_admin_expire_now=false
       ### Add additional environment variables you wish to use here.
       ### For common configuration options that you might want to use environment variables for, see `.env.example`
       ### example: bhe_database_connection=${bhe_database_connection}
@@ -88,3 +91,7 @@ services:
         condition: service_healthy
       graph-db:
         condition: service_healthy
+
+volumes:
+  neo4j-data:
+  postgres-data:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,11 +25,6 @@
     mode: "0644"
   when: not bh_installed.stat.exists
 
-- name: Set the andmin password var
-  ansible.builtin.set_fact:
-    ludus_bloodhound_admin_password: "{{ lookup('community.general.random_string', length=15, min_lower=1, min_upper=1, min_numeric=1, min_special=1, override_special='!@#$%^&*') }}"
-  when: not bh_installed.stat.exists and (ludus_bloodhound_admin_password is undefined or ludus_bloodhound_admin_password == None)
-
 - name: Copy the .env template to the host
   ansible.builtin.template:
     src: env.j2
@@ -45,7 +40,7 @@
     create: true
   when: not bh_installed.stat.exists
 
-- name: If ludus_bloodhound_listen_only_localhost is false, create .env file
+- name: If ludus_bloodhound_listen_only_localhost is false, Add to .env file
   ansible.builtin.lineinfile:
     path: "{{ ludus_bloodhound_ce_install_path }}/.env"
     line: "BLOODHOUND_HOST='0.0.0.0'"
@@ -60,7 +55,7 @@
       docker compose up -d
   when: not bh_installed.stat.exists
 
-- name: Alert
+- name: BH-CE Installation Complete
   ansible.builtin.debug:
     msg: |
       Bloodhound is up and running. Access it at http://{{ ansible_host }}:{{ ludus_bloodhound_port }} Access with: admin:{{ ludus_bloodhound_admin_password }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,7 +47,7 @@
     mode: "0644"
   when: not bh_installed.stat.exists and not ludus_bloodhound_listen_only_localhost
 
-- name: Start Bloodhound
+- name: Start BH-CE Docker Containers
   become: true
   ansible.builtin.shell:
     cmd: |
@@ -57,6 +57,10 @@
 
 - name: BH-CE Installation Complete
   ansible.builtin.debug:
-    msg: |
-      Bloodhound is up and running. Access it at http://{{ ansible_host }}:{{ ludus_bloodhound_port }} Access with: admin:{{ ludus_bloodhound_admin_password }}
+    msg: "Bloodhound is up and running!"
+  when: not bh_installed.stat.exists
+
+- name: BH-CE Credz
+  ansible.builtin.debug:
+    msg: "Access BH-CE at http://{{ ansible_host }}:{{ ludus_bloodhound_port }} using admin -> {{ ludus_bloodhound_admin_password }}"
   when: not bh_installed.stat.exists

--- a/templates/env.j2
+++ b/templates/env.j2
@@ -1,6 +1,8 @@
-BLOODHOUND_PORT='{{ ludus_bloodhound_port }}'
-bhe_default_admin_password='{{ ludus_bloodhound_admin_password }}'
-bhe_default_admin_principal_name='{{ ludus_bloodhound_admin_principal_name }}'
-bhe_default_admin_email_address='{{ ludus_bloodhound_admin_email_address }}'
-bhe_default_admin_first_name='{{ ludus_bloodhound_admin_first_name }}'
-bhe_default_admin_last_name='{{ ludus_bloodhound_admin_last_name }}'
+BLOODHOUND_PORT={{ ludus_bloodhound_port }}
+BLOODHOUND_TAG=6.0.0
+
+bhe_default_admin_principal_name={{ ludus_bloodhound_admin_principal_name }}
+bhe_default_admin_password={{ ludus_bloodhound_admin_password }}
+bhe_default_admin_email_address={{ ludus_bloodhound_admin_email_address }}
+bhe_default_admin_first_name={{ ludus_bloodhound_admin_first_name }}
+bhe_default_admin_last_name={{ ludus_bloodhound_admin_last_name }}


### PR DESCRIPTION
This PR does the following:

- Pins docker container versions to support BH-CE `6.0.0.`
- Fixes #1 
- The default admin admin will not expire now. You can change it with the role deployment by specifying `ludus_bloodhound_admin_password` in `role_vars` or by changing it in the UI once you log in as the `admin` user. 
- Defaults the `admin` password to be `bloodhoundpassword`